### PR TITLE
Add note about existing ACM certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ For more information, see [Mozilla’s web security guidelines](https://infosec.
 ## Prerequisites
 You must have a registered domain name, such as example.com, and point it to a Route53 hosted zone in the same AWS account in which you deploy this solution. For more information, see [Configuring Amazon Route 53 as your DNS service](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).
 
+> **Note:** This solution can fail if you have an existing ACM certificate for the domain name that you use with this solution. If the existing certificate is not in use, we recommend deleting it before you deploy this solution.
+
 ## Deploy the solution
 To deploy the solution, you use [AWS CloudFormation](https://aws.amazon.com/cloudformation). You can use the CloudFormation console, or download the CloudFormation template to deploy it on your own.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This solution can fail when the AWS account has a pre-existing ACM certificate for the same domain name. I added a note to this effect in the prerequisites section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
