### PR TITLE
Doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Amazon CloudFront Secure Static Website
+
 Use this solution to create a secure static website for your registered domain name. With this solution, your website:
 
 - Is hosted on [Amazon S3](https://aws.amazon.com/s3/)
@@ -49,8 +50,6 @@ For more information, see [Mozilla’s web security guidelines](https://infosec.
 
 ## Prerequisites
 You must have a registered domain name, such as example.com, and point it to a Route 53 hosted zone in the same AWS account in which you deploy this solution. For more information, see [Configuring Amazon Route 53 as your DNS service](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).
-
-> **Note:** This solution can fail if you have an existing ACM certificate for the domain name that you use with this solution. If the existing certificate is not in use, we recommend deleting it before you deploy this solution.
 
 ## Deploy the solution
 To deploy the solution, you use [AWS CloudFormation](https://aws.amazon.com/cloudformation). You can use the CloudFormation console, or download the CloudFormation template to deploy it on your own.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The security headers can help mitigate some attacks, as explained in this blog p
 For more information, see [Mozilla’s web security guidelines](https://infosec.mozilla.org/guidelines/web_security).
 
 ## Prerequisites
-You must have a registered domain name, such as example.com, and point it to a Route53 hosted zone in the same AWS account in which you deploy this solution. For more information, see [Configuring Amazon Route 53 as your DNS service](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).
+You must have a registered domain name, such as example.com, and point it to a Route 53 hosted zone in the same AWS account in which you deploy this solution. For more information, see [Configuring Amazon Route 53 as your DNS service](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).
 
 > **Note:** This solution can fail if you have an existing ACM certificate for the domain name that you use with this solution. If the existing certificate is not in use, we recommend deleting it before you deploy this solution.
 
@@ -71,7 +71,7 @@ To deploy the solution, you use [AWS CloudFormation](https://aws.amazon.com/clou
    following fields:
 
     - **SubDomain:** The subdomain for your registered domain name. Viewers use the subdomain to access your website, for example: www.example.com. We recommend using the default value of **www** as the subdomain.
-    - **DomainName:** Your registered domain name, such as example.com. This domain must be pointed to a Route53 hosted zone.
+    - **DomainName:** Your registered domain name, such as example.com. This domain must be pointed to a Route 53 hosted zone.
 
    After entering values, choose the **Next** button.
 5. On the **Configure stack options** page, you can optionally [add tags and other stack options](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-add-tags.html). When finished, choose the **Next** button.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change removes the note about potential failures due to an existing ACM certificate, which should be solved now. It also fixes a couple of typos in the Route 53 product name, which has a space between 'Route' and '53'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
