### PR TITLE
Explain how to update the Content Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ To download the CloudFormation template to deploy on your own, for example by [u
 
 https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-static-site/latest/main.yaml
 
-## Update the website content locally before deploying the solution
+## Making Changes to the Solution
+### Update the website content locally 
 
 **To customize the website with your own content before deploying the solution**
 
@@ -137,6 +138,11 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain>
     ```
+### Updating the site Content Security Policy
+
+To update the Content Security Policy of the site, update the header values located in `source/secured-headers/index.js`. 
+Deploy the solution following the steps described above in [Update the website content locally](#update-the-website-content-locally)
+
 
 ## Contributing
 Contributions are welcome. Please read the [code of conduct](CODE_OF_CONDUCT.md) and the [contributing guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To download the CloudFormation template to deploy on your own, for example by [u
 
 https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-static-site/latest/main.yaml
 
-## Making Changes to the Solution
+## Customizing the Solution
 ### Update the website content locally 
 
 **To customize the website with your own content before deploying the solution**

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
     ```
 ### Updating the site Content Security Policy
 
-To update the Content Security Policy of the site, update the header values located in `source/secured-headers/index.js`. 
-Deploy the solution following the steps described above in [Update the website content locally](#update-the-website-content-locally)
+To change the Content Security Policy of the site:
+
+1. Make your changes to the header values by editing `source/secured-headers/index.js`. 
+1. Deploy the solution by following the steps in [Update the website content locally](#update-the-website-content-locally)
 
 
 ## Contributing


### PR DESCRIPTION
A recent issue centered on updating the content security policy of the
 site. This is a common use case for customers deploying the static site
 as a template to edit.

*Issue #, if available:*

NA
*Description of changes:*

* Add a section to the readme describing where to change the content security policy header

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
