### PR TITLE
Fixes #23 Response object is too long

### DIFF
--- a/source/witch/witch.js
+++ b/source/witch/witch.js
@@ -28,7 +28,7 @@ exports.staticHandler = function(event, context) {
             ACL: "private",
         }).promise();
     })).then((msg) => {
-        respond(event, context, SUCCESS, {Message: msg});
+        respond(event, context, SUCCESS, {});
     }).catch(err => {
         respond(event, context, FAILED, {Message: err});
     });


### PR DESCRIPTION
Issue #23 

If the response message is over 4KB the stack will fail to create. The error message is CopyCustomResource | CREATE_FAILED | Response object is too long.

There is no need to respond with a success message since nothing reads it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
