### PR TITLE
Update bucket policy for serving SPA with logical routes

### DIFF
--- a/templates/cloudfront-site.yaml
+++ b/templates/cloudfront-site.yaml
@@ -49,6 +49,12 @@ Resources:
             Resource: !Sub '${S3BucketRootArn}/*'
             Principal:
               CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+          - Action:
+              - s3:ListBucket
+            Effect: Allow
+            Resource: !Sub '${S3BucketRootArn}'
+            Principal:
+              CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
 
   LambdaEdgeFunction:
     DeletionPolicy: Retain


### PR DESCRIPTION
Add policy statement to allow CloudFront OriginAccess Identity to ListBucket.  This means that when a unknown object is requested it returns a 404 instead of a 403.  For SPA hosted by CloudFront this allows for the custom error logic to serve the SPA instead of a 404 page for a logical route.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
