### PR TITLE
'url.parse' is deprecated

### DIFF
--- a/source/witch/witch.js
+++ b/source/witch/witch.js
@@ -67,11 +67,11 @@ function respond(event, context, responseStatus, responseData, physicalResourceI
     var https = require("https");
     var url = require("url");
  
-    var parsedUrl = url.parse(event.ResponseURL);
+    var parsedUrl = new url.URL(event.ResponseURL);
     var options = {
         hostname: parsedUrl.hostname,
         port: 443,
-        path: parsedUrl.path,
+        path: parsedUrl.pathname + parsedUrl.search,
         method: "PUT",
         headers: {
             "content-type": "",


### PR DESCRIPTION
'url.parse' was deprecated since v11.0.0. Use 'url.URL' constructor instead.

*Issue #, if available:*

*Description of changes:*

In the new WHATWG URL API, the URL constructor can be used to parse an URL string. And the new resulting object does not have a path field so instead we need to concatenate the pathname and search fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
