### PR TITLE
Use AWS::ACM::Certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To deploy the solution, you use [AWS CloudFormation](https://aws.amazon.com/clou
 
     - **SubDomain:** The subdomain for your registered domain name. Viewers use the subdomain to access your website, for example: www.example.com. We recommend using the default value of **www** as the subdomain.
     - **DomainName:** Your registered domain name, such as example.com. This domain must be pointed to a Route 53 hosted zone.
+    - **HostedZoneId** The Route 53 Hosted Zone Id containing the domain being used. 
     - **CreateApex:** Optionally create an Alias to the domain apex (example.com) in your CloudFront configuration.  Default is [no]
 
    After entering values, choose the **Next** button.
@@ -138,7 +139,7 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
         --stack-name <your CloudFormation stack name> \
         --template-file packaged.template \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-        --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain>
+        --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain> HostedZoneId=<hosted zone id>
     ```
     
 8. [Optional] Run the following command to deploy the packaged CloudFormation template to a CloudFormation stack with a domain apex.
@@ -148,7 +149,7 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
         --stack-name <your CloudFormation stack name> \
         --template-file packaged.template \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-        --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain> CreateApex=yes
+        --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain> HostedZoneId=<hosted zone id> CreateApex=yes
     ```
 
 

--- a/templates/acm-certificate.yaml
+++ b/templates/acm-certificate.yaml
@@ -4,16 +4,11 @@ Description: ACFS3 - Certificate creation
 Parameters:
   DomainName:
     Type: String
-  Region:
-    Type: String
-    Default: 'us-east-1'
-  CFNCustomProvider:
-    Type: String
-  CopyFunction:
-    Type: String
   SubDomain:
     Type: String
   CreateApex:
+    Type: String
+  HostedZoneId:
     Type: String
 
 Conditions:
@@ -22,77 +17,21 @@ Conditions:
     - 'yes'
 
 Resources:
-  CopyCustomResource:
-    Type: "AWS::CloudFormation::CustomResource"
-    Properties:
-      ServiceToken: !Ref CopyFunction
-
   Certificate:
-    Type: Custom::Certificate
-    Properties:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties: 
       DomainName: !Sub '${SubDomain}.${DomainName}'
       SubjectAlternativeNames:
         Fn::If:
           - CreateApexConfig
           - - Ref: DomainName
           - Ref: AWS::NoValue
-      Region: !Ref Region
+      DomainValidationOptions:
+        - DomainName: !Sub '${SubDomain}.${DomainName}'
+          HostedZoneId: !Ref HostedZoneId
       ValidationMethod: DNS
-      ServiceToken: !Ref 'CFNCustomProvider'
-
-  IssuedCertificate:
-    Type: Custom::IssuedCertificate
-    Properties:
-      CertificateArn: !Ref Certificate
-      ServiceToken: !Ref 'CFNCustomProvider'
-
-  CertificateDNSRecord:
-    Type: Custom::CertificateDNSRecord
-    Properties:
-      CertificateArn: !Ref Certificate
-      DomainName: !Sub '${SubDomain}.${DomainName}'
-      ServiceToken: !Ref 'CFNCustomProvider'
-
-  apexCertificateDNSRecord:
-    Type: Custom::CertificateDNSRecord
-    Condition: CreateApexConfig
-    Properties:
-      CertificateArn: !Ref Certificate
-      DomainName: !Ref DomainName
-      ServiceToken: !Ref 'CFNCustomProvider'
-
-  DomainValidationRecord:
-    Type: AWS::Route53::RecordSetGroup
-    Properties:
-      HostedZoneName: !Sub '${DomainName}.'
-      RecordSets:
-        - Name: !GetAtt CertificateDNSRecord.Name
-          Type: !GetAtt CertificateDNSRecord.Type
-          TTL: 60
-          Weight: 1
-          SetIdentifier: !Ref Certificate
-          ResourceRecords:
-            - !GetAtt CertificateDNSRecord.Value
-
-  apexDomainValidationRecord:
-    Type: AWS::Route53::RecordSetGroup
-    Condition: CreateApexConfig
-    Properties:
-      HostedZoneName: !Sub '${DomainName}.'
-      RecordSets:
-        - Name: !GetAtt apexCertificateDNSRecord.Name
-          Type: !GetAtt apexCertificateDNSRecord.Type
-          TTL: 60
-          Weight: 1
-          SetIdentifier: !Ref Certificate
-          ResourceRecords:
-            - !GetAtt apexCertificateDNSRecord.Value
 
 Outputs:
-  DNSRecord:
-    Description: DNS record
-    Value: !Sub '${CertificateDNSRecord.Name} ${CertificateDNSRecord.Type} ${CertificateDNSRecord.Value}'
-
   CertificateArn: 
     Description: Issued certificate
     Value: !Ref Certificate

--- a/templates/acm-certificate.yaml
+++ b/templates/acm-certificate.yaml
@@ -18,7 +18,7 @@ Conditions:
 
 Resources:
   Certificate:
-    Type: "AWS::CertificateManager::Certificate"
+    Type: AWS::CertificateManager::Certificate
     Properties: 
       DomainName: !Sub '${SubDomain}.${DomainName}'
       SubjectAlternativeNames:

--- a/templates/cloudfront-site.yaml
+++ b/templates/cloudfront-site.yaml
@@ -135,8 +135,7 @@ Resources:
       Type: AWS::CloudFront::ResponseHeadersPolicy
       Properties: 
         ResponseHeadersPolicyConfig: 
-          Comment: "practera-security-headers-for-${env:APPV2S3BUCKET}"
-          Name: "practera-security-headers-for-GlobalAPPv2"
+          Name: !Sub "${AWS::StackName}-static-site-security-headers"
           SecurityHeadersConfig: 
             StrictTransportSecurity: 
               AccessControlMaxAgeSec: 63072000

--- a/templates/custom-resource.yaml
+++ b/templates/custom-resource.yaml
@@ -3,72 +3,6 @@ Description: ACFS3 - Cert Provider with DNS validation
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
-  LambdaPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt CFNCustomProvider.Arn
-      Principal: !GetAtt LambdaRole.Arn
-
-  LambdaPolicy:
-    Type: AWS::IAM::Policy
-    DependsOn:
-      - LambdaRole
-    Properties:
-      PolicyName: CFNCertificateDomainResourceRecordProvider
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - acm:RequestCertificate
-              - acm:DescribeCertificate
-              - acm:UpdateCertificateOptions
-              - acm:DeleteCertificate
-            Resource:
-            - '*'
-          - Effect: Allow
-            Action:
-              - logs:*
-            Resource: arn:aws:logs:*:*:*
-      Roles:
-        - !Ref LambdaRole
-
-  LambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-      Tags:
-        - Key: Solution
-          Value: ACFS3
-
-  CFNCustomProviderLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      RetentionInDays: 7
-      LogGroupName: !Sub '/aws/lambda/${CFNCustomProvider}'
-    DependsOn:
-      - CFNCustomProvider
-
-  CFNCustomProvider:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: s3://binxio-public-us-east-1/lambdas/cfn-certificate-provider-0.2.4.zip
-      Description: CFN Certificate Domain Resource Record Provider
-      MemorySize: 128
-      Handler: provider.handler
-      Timeout: 300
-      Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.6
-
   S3BucketLogs:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -135,7 +69,6 @@ Resources:
                 - arn:aws:s3:::${TargetBucket}
                 - TargetBucket: !Ref S3BucketRoot
 
-
   CopyFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -166,9 +99,6 @@ Outputs:
   S3BucketLogsName:
     Description: Logging bucket Name
     Value: !GetAtt S3BucketLogs.DomainName
-  CFNCustomProvider:
-    Description: ACM helper function
-    Value: !GetAtt CFNCustomProvider.Arn
   CopyFunction:
     Description: S3 helper function
     Value: !GetAtt CopyFunction.Arn

--- a/templates/main.yaml
+++ b/templates/main.yaml
@@ -24,6 +24,9 @@ Parameters:
   DomainName:
     Description: The part of a website address after your SubDomain - e.g. example.com
     Type: String
+  HostedZoneId:
+    Description: HostedZoneId for the domain e.g. Z23ABC4XYZL05B
+    Type: String
   CreateApex:
     Description: Create an Apex Alias in CloudFront distribution - yes/no
     Type: String
@@ -46,9 +49,8 @@ Resources:
       Parameters:
         SubDomain: !Ref SubDomain
         DomainName: !Ref DomainName
-        CFNCustomProvider: !GetAtt CustomResourceStack.Outputs.CFNCustomProvider
-        CopyFunction: !GetAtt CustomResourceStack.Outputs.CopyFunction
         CreateApex: !Ref CreateApex
+        HostedZoneId: !Ref HostedZoneId
       Tags:
         - Key: Solution
           Value: ACFS3
@@ -74,9 +76,6 @@ Resources:
 Outputs:
   SolutionVersion:
     Value: !FindInMap [Solution, Constants, Version]
-  CFNCustomProvider:
-    Description: ACM helper function    
-    Value: !GetAtt CustomResourceStack.Outputs.CFNCustomProvider
   CopyFunction:
     Description: S3 helper function    
     Value: !GetAtt CustomResourceStack.Outputs.CopyFunction


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replace Custom Resource used to provision ACM Certificate with `AWS::ACM::Certificate` resource.

In order for automatic validation to occur, the hosted zone id for the domain is required. To achieve this, I've added a parameter for `HostedZoneId`.

I wasn't keen to add another parameter, especially as I think we could derive the HostedZoneId from the domain in a custom resource, but this adds extra complexity and potential to go wrong.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
