### PR TITLE
Remove step from release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,6 @@ jobs:
       # Package and Upload Archive
       - name: Pre-Package Copy Function
         run: cd source/witch/ && npm install --prefix nodejs mime-types && cp witch.js nodejs/node_modules/ && zip -r ../../witch.zip nodejs  && cd ../../
-      - name: Pre-Package Function
-        run: cd source/secured-headers/ && zip -r ../../s-headers.zip index.js && cd ../../
       - name: Package Release
         run: zip -r packaged.zip -@ < ci/include.lst
       - name: Upload Release


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `release` github action broke in a prior PR. The action tried to zip a directory that no longer exists.
This PR fixes the action by removing the step. It is no longer needed, as the function using that code has been removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
