### PR TITLE
Remove s-headers from cfn-publish

### DIFF
--- a/cfn-publish.config
+++ b/cfn-publish.config
@@ -1,5 +1,5 @@
 template=templates/main.yaml
 acl="public-read"
-extra_files="witch.zip s-headers.zip www/index.html www/css/style.css www/404.html www/other.html"
+extra_files="witch.zip www/index.html www/css/style.css www/404.html www/other.html"
 bucket_name_prefix="solution-builders"
 regions="us-east-1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The release publication failed because `cfn-publish` was looking for a file, `s-headers.zip` that no longer exists.
This PR removes the object from the list of extra files to upload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
