### PR TITLE
Add CopyFunc custom resource

### DIFF
--- a/templates/custom-resource.yaml
+++ b/templates/custom-resource.yaml
@@ -3,6 +3,12 @@ Description: ACFS3 - Cert Provider with DNS validation
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
+
+  CopyCustomResource:
+    Type: "AWS::CloudFormation::CustomResource"
+    Properties:
+      ServiceToken: !GetAtt CopyFunction.Arn
+
   S3BucketLogs:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -30,7 +36,7 @@ Resources:
       Tags:
         - Key: Solution
           Value: ACFS3
-  
+
   CopyLayerVersion:
     Type: "AWS::Serverless::LayerVersion"
     Properties:

--- a/templates/main.yaml
+++ b/templates/main.yaml
@@ -13,7 +13,7 @@ Metadata:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.6'
+      Version: 'v0.7'
 
 Parameters:
   SubDomain:


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
The CopyFunc Custom Resource was removed in a prior PR #42 
This meant that the CopyFunc is not invoked when the template is deployed, so the website files are not uploaded to the S3 bucket.

This PR replaces the custom resource to invoke the CopyFunc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
