### PR TITLE
Add apex domain validation

### DIFF
--- a/templates/acm-certificate.yaml
+++ b/templates/acm-certificate.yaml
@@ -12,14 +12,14 @@ Parameters:
     Type: String
 
 Conditions:
-  CreateApexConfig:  !Equals 
+  CreateApexConfig:  !Equals
     - !Ref CreateApex
     - 'yes'
 
 Resources:
   Certificate:
     Type: AWS::CertificateManager::Certificate
-    Properties: 
+    Properties:
       DomainName: !Sub '${SubDomain}.${DomainName}'
       SubjectAlternativeNames:
         Fn::If:
@@ -29,9 +29,14 @@ Resources:
       DomainValidationOptions:
         - DomainName: !Sub '${SubDomain}.${DomainName}'
           HostedZoneId: !Ref HostedZoneId
+        - Fn::If:
+          - CreateApexConfig
+          - - DomainName: !Ref DomainName
+              HostedZoneId: !Ref HostedZoneId
+          - Ref: AWS::NoValue
       ValidationMethod: DNS
 
 Outputs:
-  CertificateArn: 
+  CertificateArn:
     Description: Issued certificate
     Value: !Ref Certificate


### PR DESCRIPTION
*Issue #, if available:*
#53 
*Description of changes:*
This PR adds domain validation for the apex record if required.

This feature previously existed in the sample, but was accidentally omitted when I refactored the provisioning of certificates from the custom resource to use `AWS::ACM::Certificate`.

## Testing

I have tested this by deploying the template, creating an apex domain. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
