### PR TITLE
Explicitly enable S3 ACLs for logging bucket

### DIFF
--- a/templates/custom-resource.yaml
+++ b/templates/custom-resource.yaml
@@ -13,7 +13,9 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/templates/main.yaml
+++ b/templates/main.yaml
@@ -13,7 +13,7 @@ Metadata:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.8'
+      Version: 'v0.9'
 
 Rules:
   OnlyUsEast1:


### PR DESCRIPTION
*Issue #, if available:*
#60 

*Description of changes:*
This is needed due to default behaviour changes in S3[1]. 
The new behaviour breaks new deployments due to AccessControl being an ACL directive, and ACLs being disabled-by-default. It is necessary for us to enable ACLs as currently CloudFront only supports logging to S3 buckets with ACLs enabled. Bucket policies are not an alternate option, CloudFront will refuse to deploy if the logging bucket does not support ACLs.

The OwnershipControls rule enables ACL behaviours. Note that I have chosen to set this to "Bucket owner preferred" which is not the default value. This seems like the more appopriate option - it allows ACLs to continue to be enabled but makes new objects owned by the bucket owner's account. See the docs[3] for more info.

References:

https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
