### PR TITLE
Update instructions for modifying security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
 
 To change the Response Header Policy of the site:
 
-1. Make your changes by editing ResponseHeadersPolicy in ./templates/cloudfront-site.yaml. Here you can modify any of the headers for Strict-Transport-Security, Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy. 
+1. Make your changes by editing ResponseHeadersPolicy in `templates/cloudfront-site.yaml`. Here you can modify any of the headers for Strict-Transport-Security, Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy. 
 2. Deploy the solution by following the steps in [Update the website content locally](#update-the-website-content-locally)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
        --parameter-overrides  DomainName=<your domain name> SubDomain=<your website subdomain> HostedZoneId=<hosted zone id> CreateApex=yes
    ```
 
-### Updating the site Content Security Policy
+### Updating the site Response Headers
 
-To change the Content Security Policy of the site:
+To change the Response Header Policy of the site:
 
-1. Make your changes to the header values by editing `source/secured-headers/index.js`.
-1. Deploy the solution by following the steps in [Update the website content locally](#update-the-website-content-locally)
+1. Make your changes by editing ResponseHeadersPolicy in ./templates/cloudfront-site.yaml. Here you can modify any of the headers for Strict-Transport-Security, Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy. 
+2. Deploy the solution by following the steps in [Update the website content locally](#update-the-website-content-locally)
 
 ## Contributing
 


### PR DESCRIPTION
The code example no longer uses lambda@edge to configure security headers, so this pull request just updates the instructions on how to change the security headers.

*Issue #, if available:*  73

*Description of changes:*

 1) Retitle "Updating the site Content Security Policy" to "Updating the site Response Headers"
 2) Update instructions to modify `templates/cloudfront-site.yaml` instead of `source/secured-headers/index.js` which no longer exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
