### PR TITLE
Set a custom resource timeout

### DIFF
--- a/templates/custom-resource.yaml
+++ b/templates/custom-resource.yaml
@@ -6,7 +6,8 @@ Resources:
   CopyCustomResource:
     Type: 'AWS::CloudFormation::CustomResource'
     Properties:
-      ServiceToken: !GetAtt CopyFunction.Arn
+      ServiceToken: !GetAtt CopyFunction.Arn 
+      ServiceTimeout: 30
 
   S3BucketLogs:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a custom resource timeout. This improves the user and developer experience. If the custom resource fails during deployment, then the cloudformation stack will fail faster. The default custom resource timeout is 1 hour, causing failed deployments to hang until then. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
