### PR TITLE
Minor improvement to the README.md (added the region option when creating the S3 bucket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ https://s3.amazonaws.com/solution-builders-us-east-1/amazon-cloudfront-secure-st
 5. If you don’t have one already, create an S3 bucket to store the CloudFormation artifacts. To create one, use the following AWS CLI command:
 
    ```shell
-   aws s3 mb s3://<S3 bucket name>
+   aws s3 mb s3://<S3 bucket name> --region us-east-1
    ```
 
 6. Run the following AWS CLI command to package the CloudFormation template. The template uses the [AWS Serverless Application Model](https://aws.amazon.com/about-aws/whats-new/2016/11/introducing-the-aws-serverless-application-model/), so it must be transformed before you can deploy it.

--- a/templates/main.yaml
+++ b/templates/main.yaml
@@ -16,7 +16,7 @@ Metadata:
 Mappings:
   Solution:
     Constants:
-      Version: 'v0.13'
+      Version: 'v0.14'
 
 Rules:
   OnlyUsEast1:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Since the CloudFormation template can only be deployed in the `us-east-1` region, I believe the S3 bucket must be in the same region. I have added the `--region` option to the `aws s3 mb` command in the `README.md` to improve the documentation.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
