### PR TITLE
Fix CFN Nag scan

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.4.4'
       - run: gem install cfn-nag
       - uses: actions/checkout@v2
       # Run Tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix CFN Nag scan by bumping ruby version. This address an issue observed in a recent PR where the action failed
[GH Action - CFN Nag](https://github.com/aws-samples/amazon-cloudfront-secure-static-site/actions/runs/16174521279/job/45702675644) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
