### PR TITLE
Upgrade to node 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ witch.zip
 **/npm-debug.log
 **/testem.log
 **/.env
-# package-lock.json
 **/.vscode/settings.json
 **/setenv.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ witch.zip
 **/node_modules
 **/coverage
 **/package.json
+**/package-lock.json
 
 # e2e
 **/e2e/*.js

--- a/source/witch/witch.js
+++ b/source/witch/witch.js
@@ -12,34 +12,33 @@ const FAILED = 'FAILED';
 
 const { BUCKET } = process.env;
 
-exports.staticHandler = (event, context) => {
+exports.staticHandler = async (event, context) => {
   if (event.RequestType !== 'Create' && event.RequestType !== 'Update') {
-    return respond(event, context, SUCCESS, {});
+    await respond(event, context, SUCCESS, {});
+    return;
   }
 
-  Promise.all(
-    walkSync('./').map((file) => {
-      const fileType = mime.lookup(file) || 'application/octet-stream';
+  try {
+    await Promise.all(
+      walkSync('./').map((file) => {
+        const fileType = mime.lookup(file) || 'application/octet-stream';
 
-      console.log(`${file} -> ${fileType}`);
+        console.log(`${file} -> ${fileType}`);
 
-      return s3Client.send(
-        new PutObjectCommand({
-          Body: fs.createReadStream(file),
-          Bucket: BUCKET,
-          ContentType: fileType,
-          Key: file,
-          ACL: 'private',
-        })
-      );
-    })
-  )
-    .then((msg) => {
-      respond(event, context, SUCCESS, {});
-    })
-    .catch((err) => {
-      respond(event, context, FAILED, { Message: err });
-    });
+        return s3Client.send(
+          new PutObjectCommand({
+            Body: fs.createReadStream(file),
+            Bucket: BUCKET,
+            ContentType: fileType,
+            Key: file,
+          })
+        );
+      })
+    );
+    await respond(event, context, SUCCESS, {});
+  } catch (err) {
+    await respond(event, context, FAILED, { Message: String(err) });
+  }
 };
 
 // List all files in a directory in Node.js recursively in a synchronous fashion
@@ -57,14 +56,7 @@ function walkSync(dir, filelist = []) {
   return filelist;
 }
 
-function respond(
-  event,
-  context,
-  responseStatus,
-  responseData,
-  physicalResourceId,
-  noEcho
-) {
+function respond(event, context, responseStatus, responseData, physicalResourceId, noEcho) {
   const responseBody = JSON.stringify({
     Status: responseStatus,
     Reason: `See the details in CloudWatch Log Stream: ${context.logStreamName}`,
@@ -78,29 +70,31 @@ function respond(
 
   console.log('Response body:\n', responseBody);
 
-  const { pathname, hostname, search } = new url.URL(event.ResponseURL);
-  const options = {
-    hostname,
-    port: 443,
-    path: pathname + search,
-    method: 'PUT',
-    headers: {
-      'content-type': '',
-      'content-length': responseBody.length,
-    },
-  };
+  return new Promise((resolve, reject) => {
+    const { pathname, hostname, search } = new url.URL(event.ResponseURL);
+    const options = {
+      hostname,
+      port: 443,
+      path: pathname + search,
+      method: 'PUT',
+      headers: {
+        'content-type': '',
+        'content-length': Buffer.byteLength(responseBody),
+      },
+    };
 
-  const request = https.request(options, (response) => {
-    console.log(`Status code: ${response.statusCode}`);
-    console.log(`Status message: ${response.statusMessage}`);
-    context.done();
+    const request = https.request(options, (response) => {
+      console.log(`Status code: ${response.statusCode}`);
+      console.log(`Status message: ${response.statusMessage}`);
+      resolve();
+    });
+
+    request.on('error', (error) => {
+      console.log(`send(..) failed executing https.request(..): ${error}`);
+      reject(error);
+    });
+
+    request.write(responseBody);
+    request.end();
   });
-
-  request.on('error', (error) => {
-    console.log(`send(..) failed executing https.request(..): ${error}`);
-    context.done();
-  });
-
-  request.write(responseBody);
-  request.end();
 }

--- a/templates/custom-resource.yaml
+++ b/templates/custom-resource.yaml
@@ -44,7 +44,7 @@ Resources:
     Properties:
       ContentUri: ../witch.zip
       CompatibleRuntimes:
-        - nodejs20.x
+        - nodejs24.x
 
   CopyRole:
     Type: 'AWS::IAM::Role'
@@ -88,7 +88,7 @@ Resources:
       Layers:
         - !Ref CopyLayerVersion
       Role: !GetAtt CopyRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs24.x
       Timeout: 300
 
 Outputs:


### PR DESCRIPTION
Issue #87

`templates/custom-resource.yaml` bumped from nodejs20.x to nodejs24.x

`source/witch/witch.js` updated to use async/await because support for context.done() has been removed now https://aws.amazon.com/blogs/compute/node-js-24-runtime-now-available-in-aws-lambda/

Testing wise, I've used the customised build from this branch to deploy a new site, and upgraded all of my existing static sites too and they work. Note that upgrading causes the placeholder assets in `www` to get re-uploaded but that's the existing behaviour.

These were the last of my node 20 lambdas that needed patching, hope this helps others stay up to date too.

---

<img width="2137" height="713" alt="Screenshot 2026-03-01 at 14 28 17" src="https://github.com/user-attachments/assets/2469b0bc-99a1-4280-adee-4896aa16f44c" />
<img width="2417" height="266" alt="Screenshot 2026-03-01 at 14 28 43" src="https://github.com/user-attachments/assets/e7d16694-7ab6-4bc1-8808-c84314561f82" />
<img width="2433" height="704" alt="Screenshot 2026-03-01 at 14 29 13" src="https://github.com/user-attachments/assets/dd4a90c9-0887-426b-9128-7cc7dbf81600" />


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
